### PR TITLE
Support Angular 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ An Angular 2 module for simple desktop file drag and drop with automatic file va
 ![](https://cloud.githubusercontent.com/assets/1649415/18009234/3c180d48-6ba3-11e6-9f21-c71d3b1f7bd8.gif)
 
 ## Dependancies
-Currently built against Angular 2.0.0
+Currently built against Angular 2.4.6, but should work with any 2.x version.
 
 ng2-file-drop has the following additional dependancies
 - [TsLerp](https://www.npmjs.com/package/tslerp): Typescript library for lerping single and multi-sample data sets over time
@@ -32,7 +32,7 @@ ng2-file-drop has the following additional dependancies
 ## Installation
 1. Add the package to your 'dependencies' list in `package.json` and run `npm install`
 
-  `"ng2-file-drop": "^0.2.0"`
+  `"ng2-file-drop": "^0.2.1"`
   
   Optionally, you can manually install the package using the npm command line
 
@@ -326,6 +326,9 @@ export class MyCustomComponent {
 <br>
 
 ## Change Log
+
+### 0.2.1
+* Support for Angular versions 2.0.0 - 2.4.7
 
 ### 0.2.0
 * Fixed - Safari Issue: Can't find variable: DragEvent - https://github.com/leewinder/ng2-file-drop/issues/4

--- a/development/package.json
+++ b/development/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ng2-file-drop",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "license": "MIT",
     "description": "An Angular 2 module for simple desktop file drag and drop",
     "private": false,
@@ -30,9 +30,9 @@
         "typings": "typings"
     },
     "dependencies": {
-        "@angular/core": "2.0.0",
-        "@angular/common": "2.0.0",
-        "@angular/platform-browser": "2.0.0",
+        "@angular/core": "^2.0.0",
+        "@angular/common": "^2.0.0",
+        "@angular/platform-browser": "^2.0.0",
         "core-js": "^2.4.1",
         "rxjs": "5.0.0-beta.12",
         "systemjs": "0.19.27",

--- a/samples/package.json
+++ b/samples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-file-drop-samples",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "scripts": {
     "start": "tsc && concurrently \"npm run tsc:w\" \"npm run lite\" ",
     "lite": "lite-server",
@@ -15,11 +15,11 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@angular/common": "2.0.0",
-    "@angular/compiler": "2.0.0",
-    "@angular/core": "2.0.0",
-    "@angular/platform-browser": "2.0.0",
-    "@angular/platform-browser-dynamic": "2.0.0",
+    "@angular/common": "^2.4.6",
+    "@angular/compiler": "^2.4.6",
+    "@angular/core": "^2.4.6",
+    "@angular/platform-browser": "^2.4.6",
+    "@angular/platform-browser-dynamic": "^2.4.6",
     "bootstrap": "^3.3.7",
     "core-js": "^2.4.1",
     "rxjs": "5.0.0-beta.12",


### PR DESCRIPTION
0.2.0 pins itself to Angular 2.0.0, which causes problems for projects that use later versions of Angular. This change loosens the dependency to `"@angular/*": "^2.0.0"`, which will support any 2.x version. Tested against Angular 2.4.6.

See #8 